### PR TITLE
Tabulation problems with markdown-it v8.3.0

### DIFF
--- a/v0.3.0/fixtures/api_data.js
+++ b/v0.3.0/fixtures/api_data.js
@@ -1581,7 +1581,7 @@ define({ "api": [
     "url": "/indent/trim/multi/tabs",
     "title": "Trim multi line (tabs)",
     "group": "indent",
-    "description": "<p>Text line 1 (Begin: 3xTab (2 removed)). \t\tText line 2 (Begin: 2x Tab (2 removed), End: 1xTab).</p>",
+    "description": "<p>Text line 1 (Begin: 3xTab (2 removed)). Text line 2 (Begin: 2x Tab (2 removed), End: 1xTab).</p>",
     "version": "0.0.0",
     "filename": "src/indent.js",
     "groupTitle": "Indent",


### PR DESCRIPTION
Hi,
The last release of markdown-it (8.3.0) breaks the tests. It is the consequence of the resolution of two bugs with tabulation, as mentioned on the change log: https://github.com/markdown-it/markdown-it/blob/master/CHANGELOG.md